### PR TITLE
invalid projectMappings.json

### DIFF
--- a/dartabase_migration/bin/dartabaseMigration.dart
+++ b/dartabase_migration/bin/dartabaseMigration.dart
@@ -63,7 +63,7 @@ void initiateDartabase(path, projectName) {
       "schemaVersion": ""
     };
     DBCore.mapToJsonFilePath(schemaVersion, "$path/db/schemaVersion.json");
-//    exit(0);
+    exit(0);
 
   });
 }


### PR DESCRIPTION
Problem: fix issue when running dbInit.dart from command line - exit does not occur, hitting any-key after the inititalization has finished kicks off an event handler and causes an invalid map to be written to the projectMappings.json

Fix: exit when complete
